### PR TITLE
repair undefined variable in setting timer repeat

### DIFF
--- a/lib/libuv/timer.rb
+++ b/lib/libuv/timer.rb
@@ -55,7 +55,7 @@ module Libuv
         def repeat=(repeat)
             return if @closed
             repeat = repeat.to_i
-            check_result ::Libuv::Ext.timer_set_repeat(handle, repeat)
+            error = check_result ::Libuv::Ext.timer_set_repeat(handle, repeat)
             reject(error) if error
         end
 

--- a/spec/timer_spec.rb
+++ b/spec/timer_spec.rb
@@ -1,0 +1,14 @@
+require 'libuv'
+
+describe Libuv::Timer do
+	describe 'setting properties' do
+		it "should allow repeat to be set" do
+      @loop = Libuv::Loop.new
+			@loop.run { |logger|
+        @timer = @loop.timer
+        @timer.repeat = 5
+        expect(@timer.repeat).to eq(5)
+      }
+    end
+  end
+end


### PR DESCRIPTION
Fixes:

```
 NameError:
   undefined local variable or method `error' for #<Libuv::Timer:0x007fd95188c598>
 # ./lib/libuv/timer.rb:60:in `repeat='
```
