### PR TITLE
repair bindings to libuv uv_tcp_bind function

### DIFF
--- a/lib/libuv/ext/ext.rb
+++ b/lib/libuv/ext/ext.rb
@@ -129,7 +129,7 @@ module Libuv
         attach_function :tcp_nodelay, :uv_tcp_nodelay, [:uv_tcp_t, :int], :int, :blocking => true
         attach_function :tcp_keepalive, :uv_tcp_keepalive, [:uv_tcp_t, :int, :uint], :int, :blocking => true
         attach_function :tcp_simultaneous_accepts, :uv_tcp_simultaneous_accepts, [:uv_tcp_t, :int], :int, :blocking => true
-        attach_function :tcp_bind, :uv_tcp_bind, [:uv_tcp_t, :sockaddr_in], :int, :blocking => true
+        attach_function :tcp_bind, :uv_tcp_bind, [:uv_tcp_t, :sockaddr_in, :uint], :int, :blocking => true
         attach_function :tcp_getsockname, :uv_tcp_getsockname, [:uv_tcp_t, :pointer, :pointer], :int, :blocking => true
         attach_function :tcp_getpeername, :uv_tcp_getpeername, [:uv_tcp_t, :pointer, :pointer], :int, :blocking => true
         attach_function :tcp_connect, :uv_tcp_connect, [:uv_connect_t, :uv_tcp_t, :sockaddr_in, :uv_connect_cb], :int, :blocking => true

--- a/lib/libuv/tcp.rb
+++ b/lib/libuv/tcp.rb
@@ -371,7 +371,7 @@ module Libuv
             end
 
             def bind
-                check_result! ::Libuv::Ext.tcp_bind(@tcp, ip_addr)
+                check_result! ::Libuv::Ext.tcp_bind(@tcp, ip_addr, 0)
             end
 
             def connect(callback)


### PR DESCRIPTION
@stakach this fixes an issue when `bind/listen`ing multiple TCP servers in the same reactor loop...

Without this fix, multiple calls to `a_tcp_server.bind` results in undefined / error behavior, in particular the `catch` loop on the server receives this message

`"invalid argument, EINVAL:-22","Libuv::Error::EINVAL"`

I think this error might only be an issue in particular on Linux platforms, as for the most part I have not seen this issue on OSX.

I plan to submit a test along with this patch, but I need to get this pushed and and integrated into my project sooner than later...
